### PR TITLE
Fix to run server.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -25,7 +25,7 @@ const tello = {
 // Telloにコマンド送信する関数
 const send = async (buf, ms = 0) => {
   console.log(buf);
-  const command = new Buffer(buf);
+  const command = Buffer.from(buf);
   sock.send(command, 0, command.length, tello.port, tello.ip);
   await wait(ms);
 };


### PR DESCRIPTION
https://techblog.yahoo.co.jp/advent-calendar-2016/node_new_buffer/ でも記載されている`Buffer`の脆弱性対応

起動させようとすると下記のエラーが出力されたので、その対応を行った。
```zsh
➜  drone_app git:(fix/Buffer) ✗ node server.js
command
(node:33614) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
(Use `node --trace-deprecation ...` to show where the warning was created)

```